### PR TITLE
add products to the default ranking response

### DIFF
--- a/views.py
+++ b/views.py
@@ -61,7 +61,8 @@ class PredictionsRanks(fv.MethodView):
         r_dict = {
             'user': data['user'],
             'id': uuid.uuid4().hex,
-            'topk': data['topk']
+            'topk': data['topk'],
+            'products': []
         }
 
         try:


### PR DESCRIPTION
According to the openapi definition, the rankings request should return
an empty product list on creation. This change just adds the empty
product list.