### PR TITLE
Configurable model store check rate limit

### DIFF
--- a/predictions.py
+++ b/predictions.py
@@ -9,6 +9,10 @@ import os
 from pyspark import sql as pysql
 
 
+def get_arg(env, default):
+    return os.getenv(env) if os.getenv(env, '') is not '' else default
+
+
 def loop(request_q, response_q):
     """processing loop for predictions
 
@@ -17,8 +21,8 @@ def loop(request_q, response_q):
     the response_q queue.
     """
 
-    # Get the model store backend, e.g. MODEL_STORE_URI=mongodb://localhost:27017
-    MODEL_STORE_URI = os.environ['MODEL_STORE_URI']
+    # Get the model store backend. If none provided the default is `mongodb://localhost:27017`
+    MODEL_STORE_URI = get_arg('MODEL_STORE_URI', 'mongodb://localhost:27017')
 
     # just leaving these here for future reference (elmiko)
 
@@ -59,4 +63,3 @@ def loop(request_q, response_q):
             resp.update(products=
                         [{'id': item[0], 'rating': item[1]} for item in predictions])
             response_q.put(resp)
-


### PR DESCRIPTION
At the moment, every time there's a request for the predictor, there's a hit on the model store to check for updated models.

In a high traffic scenario this can lead to a degradation of the predictor's responsiveness.

In this PR a configurable time-between-checks in milliseconds is introduced via the env var `MODEL_STORE_CHECK_RATE` (e.g. a value of `60000` will check for updated models every minute).

The previous behaviour (a check with every request) can be simulated by setting the interval to `0`.

@elmiko @zmhassan @sophwats ptal.