### PR TITLE
JDG/Infinispan cache store backend implementation

### DIFF
--- a/app.py
+++ b/app.py
@@ -33,6 +33,7 @@ def main():
     # waiting for processing loop to become active
     response_q.get()
 
+    # initialize a cache store (uses environment variables for connection information)
     storage = caches.factory()
 
     # create and start the cache updater thread

--- a/app.py
+++ b/app.py
@@ -33,7 +33,7 @@ def main():
     # waiting for processing loop to become active
     response_q.get()
 
-    storage = caches.MemoryCache()
+    storage = caches.factory()
 
     # create and start the cache updater thread
     thread = t.Thread(target=caches.updater, args=(response_q, storage))
@@ -43,16 +43,16 @@ def main():
     app.add_url_rule('/', view_func=views.ServerInfo.as_view('server'))
     app.add_url_rule('/predictions/ratings',
                      view_func=views.PredictionsRatings.as_view('rating_prediction',
-                                                         storage,
-                                                         request_q))
+                                                                storage,
+                                                                request_q))
     app.add_url_rule('/predictions/ratings/<string:p_id>',
                      view_func=views.PredictionDetail.as_view('rating_predictions',
                                                               storage))
 
     app.add_url_rule('/predictions/ranks',
                      view_func=views.PredictionsRanks.as_view('rank_prediction',
-                                                         storage,
-                                                         request_q))
+                                                              storage,
+                                                              request_q))
 
     app.add_url_rule('/predictions/ranks/<string:p_id>',
                      view_func=views.PredictionDetail.as_view('rank_predictions',

--- a/errors.py
+++ b/errors.py
@@ -19,3 +19,7 @@ class PredictionExists(Exception):
 
 class PredictionNotFound(Exception):
     pass
+
+
+class CacheError(Exception):
+    pass

--- a/predictions.py
+++ b/predictions.py
@@ -70,6 +70,8 @@ def loop(request_q, response_q):
             latest_id = model_reader.latestId()
             if model.version != latest_id:
                 model = model_reader.read(version=latest_id)
+                # invalidade the cache, since we are using a new model
+                response_q.put('invalidate')
             last_model_check = current_time
 
         req = request_q.get()


### PR DESCRIPTION
Ability to use a JDG/Infinispan cache store by providing:

 - `CACHE_TYPE`, a string of `'infinispan'` or `'jdg'`
 - `CACHE_HOST`, the JDG server address (e.g. `'127.0.0.1'`)
 - `CACHE_PORT`, the JDG server port (e.g. `8888`)
 - `CACHE_NAME`, the cache db name (e.g. `'namedCache'`)

Upon loading a new model, a new `Cache` abstract method, `invalidate`, is called which empties the JDG cache store.

_TODO_: At the moment JDG REST security must be disabled.