### PR TITLE
Guard against invalid user id in top-k requests

### DIFF
--- a/model.py
+++ b/model.py
@@ -21,6 +21,10 @@ class Model:
         self._als_model = als_model
         self._version = version
         self._data_version = data_version
+        self._products = self._als_model.productFeatures()\
+            .map(lambda x: x[0]).cache()
+        self._users = self._als_model.userFeatures() \
+            .map(lambda x: x[0]).cache()
 
     @property
     def als(self):
@@ -33,3 +37,11 @@ class Model:
         """Getter method for the model's version
         """
         return self._version
+
+    def valid_user(self, user_id):
+        valid = self._users.filter(lambda x: x == user_id).count() > 0
+        print("user {} is {}".format(user_id, valid))
+        return valid
+
+    def valid_product(self, product_id):
+        return self._users.filter(lambda x: x == product_id).count() > 0

--- a/model.py
+++ b/model.py
@@ -39,9 +39,7 @@ class Model:
         return self._version
 
     def valid_user(self, user_id):
-        valid = self._users.filter(lambda x: x == user_id).count() > 0
-        print("user {} is {}".format(user_id, valid))
-        return valid
+        return self._users.filter(lambda x: x == user_id).count() > 0
 
     def valid_product(self, product_id):
-        return self._users.filter(lambda x: x == product_id).count() > 0
+        return self._products.filter(lambda x: x == product_id).count() > 0


### PR DESCRIPTION
When requesting top-k predictions for an invalid user `id` (see #27), `MatrixFactorizationModel` crashes and Spark ALS stops providing predictions.

Since Spark's ALS model has no built-in facility to catch this, a safeguard must be built at the application logic level. The solution proposed in this PR consists of:

 - At the model loading stage extract an `RDD` of user `id`s and another of product `id`s
 - This is used by the `Model` class to implement two methods (`valid_user(id)` and `valid_product(id)`) to check if the provided `id`s are within the model
 - At the request loop, prior to performing prediction, `id`s are checked for validity and if they are not valid, the predicted top-k product list will be empty, bypassing prediction.

This prevents crashing the ALS model at the cost of one call to an `RDD` of `id`s.

Example (after patching):

Using user `id=900000` (invalid) we issue

```
curl --request POST \
   --url http://0.0.0.0:8080/predictions/ranks \
   --header 'content-type: application/json' \
   --data '{"user": 900000, "topk": 25}'
```

we get the server response

```
{
  "prediction": {
    "id": "ea632652c61c4508bed702bfecad32c7",
    "products": [],
    "topk": 25,
    "user": 900000
  }
}
```

the log alerts us:

```
2018-02-17 21:46:23,947 - jiminy-predictor - ERROR - Requesting rankings for invalid user id=900000
```

Fetching the prediction with

```
curl --request GET --url http://0.0.0.0:8080/predictions/ranks/ea632652c61c4508bed702bfecad32c7
```

Returning the response:
```
{
  "id": "ea632652c61c4508bed702bfecad32c7",
  "products": [],
  "topk": 25,
  "user": 900000
}
```

but without crashing the Spark model.